### PR TITLE
signed request does not degrade gracefully if user modifies the signed_request param.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -406,7 +406,9 @@ abstract class BaseFacebook
       if (isset($_REQUEST['signed_request'])) {
         $this->signedRequest = $this->parseSignedRequest(
           $_REQUEST['signed_request']);
-      } else if (isset($_COOKIE[$this->getSignedRequestCookieName()])) {
+      }
+      if (!$this->signedRequest &&
+          isset($_COOKIE[$this->getSignedRequestCookieName()])) {
         $this->signedRequest = $this->parseSignedRequest(
           $_COOKIE[$this->getSignedRequestCookieName()]);
       }
@@ -849,7 +851,14 @@ abstract class BaseFacebook
    * @return array The payload inside it or null if the sig is wrong
    */
   protected function parseSignedRequest($signed_request) {
-    list($encoded_sig, $payload) = explode('.', $signed_request, 2);
+    $signed_request_parts = explode('.', $signed_request, 2);
+    if(!isset($signed_request_parts[0]) || !isset($signed_request_parts[1])){
+      self::errorLog('Invalid signed request.');
+      return null;
+    }
+
+    $encoded_sig = $signed_request_parts[0];
+    $payload = $signed_request_parts[1];
 
     // decode the data
     $sig = self::base64UrlDecode($encoded_sig);


### PR DESCRIPTION
1. ensure that signed_request has at least one "." character to avoid PHP notices.
2. fall back to COOKIE signed_request if REQUEST signed_request fails to parse.
