### PR TITLE
Make getApplicationAccessToken public

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -665,7 +665,7 @@ abstract class BaseFacebook
    * @return string The application access token, useful for gathering
    *                public information about users and applications.
    */
-  protected function getApplicationAccessToken() {
+  public function getApplicationAccessToken() {
     return $this->appId.'|'.$this->appSecret;
   }
 


### PR DESCRIPTION
For posting apprequests, we need to use the application access token
not the user one. It is easy to specify this in the parameters to the api
call except that the method to retrieve it is protected. I can see no
obvious reason why.
