### PR TITLE
added setPersistentAccessToken() function

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -341,7 +341,7 @@ abstract class BaseFacebook
    * @return BaseFacebook
    */
   public function setPersistentAccessToken($access_token) {
-    $this->accessToken = $access_token;
+    $this->setAccessToken($access_token);
     $this->user = $this->getUserFromAccessToken();
     $this->setPersistentData('access_token', $access_token);
     $this->setPersistentData('user_id', $this->user);


### PR DESCRIPTION
I think that this function will be usable in cases, where programmer wants to set their access token from database, for example. Classic setAccessToken doesn't work in cases like getUser(); and similar, because $user is cached
