### PR TITLE
Add replacement method to @deprecated tags

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -219,7 +219,7 @@ abstract class BaseFacebook
 
     $state = $this->getPersistentData('state');
     if (!empty($state)) {
-      $this->state = $this->getPersistentData('state');
+      $this->state = $state;
     }
   }
 
@@ -248,7 +248,7 @@ abstract class BaseFacebook
    *
    * @param string $apiSecret The App Secret
    * @return BaseFacebook
-   * @deprecated
+   * @deprecated Use setAppSecret instead.
    */
   public function setApiSecret($apiSecret) {
     $this->setAppSecret($apiSecret);
@@ -270,7 +270,7 @@ abstract class BaseFacebook
    * Get the App Secret.
    *
    * @return string the App Secret
-   * @deprecated
+   * @deprecated Use getAppSecret instead.
    */
   public function getApiSecret() {
     return $this->getAppSecret();
@@ -306,11 +306,10 @@ abstract class BaseFacebook
   }
 
   /**
-   * DEPRECATED! Please use getFileUploadSupport instead.
-   *
    * Get the file upload support status.
    *
    * @return boolean true if and only if the server supports file upload.
+   * @deprecated Use getFileUploadSupport instead.
    */
   public function useFileUploadSupport() {
     return $this->getFileUploadSupport();


### PR DESCRIPTION
Two deprecated methods didn't say method what to use instead, and one deprecated method was marked with just a text comment--not annotation.

The constructor wasn't reusing the $state local variable pulled from persistent storage when storing the value in the object property.
