### PR TITLE
Avoid PHP notice when the "signed_request" is not well formatted.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -426,10 +426,12 @@ abstract class BaseFacebook
    */
   public function getSignedRequest() {
     if (!$this->signedRequest) {
-      if (isset($_REQUEST['signed_request'])) {
+      if (isset($_REQUEST['signed_request']) 
+      && false !== strpos($_REQUEST['signed_request'], '.')) {
         $this->signedRequest = $this->parseSignedRequest(
           $_REQUEST['signed_request']);
-      } else if (isset($_COOKIE[$this->getSignedRequestCookieName()])) {
+      } else if (isset($_COOKIE[$this->getSignedRequestCookieName()]) 
+      && false !== strpos($_COOKIE[$this->getSignedRequestCookieName()], '.')) {
         $this->signedRequest = $this->parseSignedRequest(
           $_COOKIE[$this->getSignedRequestCookieName()]);
       }


### PR DESCRIPTION
This is an alternative to #4

When the "signed_request" is modified or empty, a PHP notice is generated in `BaseFacebook:: parseSignedRequest()`.
