### PR TITLE
Add a symlink to src/facebook.php from facebook.php

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -1,0 +1,1 @@
+src/facebook.php


### PR DESCRIPTION
The symlink is needed because the app is including the Facebook SDK from include/lib/facebook/facebook.php, however the file itself is in include/lib/facebook/src/facebook.php in the repository.
