### PR TITLE
Add support for custom CURL options

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -661,6 +661,11 @@ abstract class BaseFacebook
       $user_info = $this->api('/me');
       return $user_info['id'];
     } catch (FacebookApiException $e) {
+      // Throw CURL exceptions
+      if ($e->getType() == 'CurlException') {
+        throw $e;
+      }
+
       return 0;
     }
   }
@@ -720,6 +725,11 @@ abstract class BaseFacebook
                           'redirect_uri' => $redirect_uri,
                           'code' => $code));
     } catch (FacebookApiException $e) {
+      // Throw CURL exceptions
+      if ($e->getType() == 'CurlException') {
+        throw $e;
+      }
+
       // most likely that user very recently revoked authorization.
       // In any event, we don't have an access token, so say so.
       return false;

--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -201,6 +201,13 @@ abstract class BaseFacebook
   protected $fileUploadSupport = false;
 
   /**
+   * Custom CURL options
+   *
+   * @var array
+   */
+  protected $curl_opts = array();
+
+  /**
    * Initialize a Facebook Application.
    *
    * The configuration:
@@ -853,7 +860,7 @@ abstract class BaseFacebook
       $ch = curl_init();
     }
 
-    $opts = self::$CURL_OPTS;
+    $opts = $this->getCurlOptions();
     if ($this->getFileUploadSupport()) {
       $opts[CURLOPT_POSTFIELDS] = $params;
     } else {
@@ -1219,6 +1226,26 @@ abstract class BaseFacebook
     }
 
     return $metadata;
+  }
+
+  /**
+   * Set custom CURL options.
+   *
+   * @param array $curlOptions CURL options
+   * @return BaseFacebook
+   */
+  public function setCurlOptions(array $curlOptions) {
+    $this->curl_opts = $curlOptions;
+    return $this;
+  }
+
+  /**
+   * Get CURL options (default + custom).
+   *
+   * @return array CURL options
+   */
+  public function getCurlOptions() {
+    return $this->curl_opts + self::$CURL_OPTS;
   }
 
   /**


### PR DESCRIPTION
Add support for adding custom CURL options, e.g. $facebook->setCurlOptions(array(CURLOPT_SSLVERSION => 3)).

It seems that most Facebook servers hang with new openssl library where TLS 1.2 is default, and this is solution which covers possible future problems. Quick fix would be adding  "CURLOPT_SSLVERSION => 3" to $CURL_OPTS.

SSL/TLS problems are related to this bugs:
http://rt.openssl.org/Ticket/Display.html?id=2771
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=665452
https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/965371

This one hangs (no response from server):

$ openssl s_client -msg -host 69.171.229.25 -port 443
CONNECTED(00000003)

> > > TLS 1.2  [length 013b]
> > >     01 00 01 37 03 03 4f 7d 41 e2 8a 8d 37 85 cb 62
> > >     85 6d e1 f3 82 34 a4 8d 42 96 73 3d 4b 2f e1 fc
> > >     cd 56 17 be fc b1 00 00 9e c0 30 c0 2c c0 28 c0
> > >     24 c0 14 c0 0a c0 22 c0 21 00 a3 00 9f 00 6b 00
> > >     6a 00 39 00 38 00 88 00 87 c0 32 c0 2e c0 2a c0
> > >     26 c0 0f c0 05 00 9d 00 3d 00 35 00 84 c0 12 c0
> > >     08 c0 1c c0 1b 00 16 00 13 c0 0d c0 03 00 0a c0
> > >     2f c0 2b c0 27 c0 23 c0 13 c0 09 c0 1f c0 1e 00
> > >     a2 00 9e 00 67 00 40 00 33 00 32 00 9a 00 99 00
> > >     45 00 44 c0 31 c0 2d c0 29 c0 25 c0 0e c0 04 00
> > >     9c 00 3c 00 2f 00 96 00 41 c0 11 c0 07 c0 0c c0
> > >     02 00 05 00 04 00 15 00 12 00 09 00 14 00 11 00
> > >     08 00 06 00 03 00 ff 02 01 00 00 6f 00 0b 00 04
> > >     03 00 01 02 00 0a 00 34 00 32 00 0e 00 0d 00 19
> > >     00 0b 00 0c 00 18 00 09 00 0a 00 16 00 17 00 08
> > >     00 06 00 07 00 14 00 15 00 04 00 05 00 12 00 13
> > >     00 01 00 02 00 03 00 0f 00 10 00 11 00 23 00 00
> > >     00 0d 00 22 00 20 06 01 06 02 06 03 05 01 05 02
> > >     05 03 04 01 04 02 04 03 03 01 03 02 03 03 02 01
> > >     02 02 02 03 01 01 00 0f 00 01 01

This one works (supports TLS 1.2):

$ openssl s_client  -msg -host 69.171.234.18 -port 443
CONNECTED(00000003)

> > > TLS 1.2  [length 013b]
> > >     01 00 01 37 03 03 4f 7d 45 5a 87 36 98 cb 4f 30
> > >     48 64 5c 0d a8 56 b6 4c 58 d8 73 66 96 0d c6 67
> > >     68 c6 17 82 ad c7 00 00 9e c0 30 c0 2c c0 28 c0
> > >     24 c0 14 c0 0a c0 22 c0 21 00 a3 00 9f 00 6b 00
> > >     6a 00 39 00 38 00 88 00 87 c0 32 c0 2e c0 2a c0
> > >     26 c0 0f c0 05 00 9d 00 3d 00 35 00 84 c0 12 c0
> > >     08 c0 1c c0 1b 00 16 00 13 c0 0d c0 03 00 0a c0
> > >     2f c0 2b c0 27 c0 23 c0 13 c0 09 c0 1f c0 1e 00
> > >     a2 00 9e 00 67 00 40 00 33 00 32 00 9a 00 99 00
> > >     45 00 44 c0 31 c0 2d c0 29 c0 25 c0 0e c0 04 00
> > >     9c 00 3c 00 2f 00 96 00 41 c0 11 c0 07 c0 0c c0
> > >     02 00 05 00 04 00 15 00 12 00 09 00 14 00 11 00
> > >     08 00 06 00 03 00 ff 02 01 00 00 6f 00 0b 00 04
> > >     03 00 01 02 00 0a 00 34 00 32 00 0e 00 0d 00 19
> > >     00 0b 00 0c 00 18 00 09 00 0a 00 16 00 17 00 08
> > >     00 06 00 07 00 14 00 15 00 04 00 05 00 12 00 13
> > >     00 01 00 02 00 03 00 0f 00 10 00 11 00 23 00 00
> > >     00 0d 00 22 00 20 06 01 06 02 06 03 05 01 05 02
> > >     05 03 04 01 04 02 04 03 03 01 03 02 03 03 02 01
> > >     02 02 02 03 01 01 00 0f 00 01 01
> > > <<< TLS 1.2  [length 0051]
> > >     02 00 00 4d 03 03 8a 1a 5a f5 d4 46 82 16 af c4
> > >     80 6a 78 88 e3 36 00 96 22 a9 2b 5f a8 9d 69 f6
> > >     43 04 49 46 37 44 20 1c 9e 2a 06 c2 6e b2 91 c1
> > >     dc 74 5a 40 e4 74 3e d4 e3 c2 bd 16 90 27 6a 2b
> > >     64 c8 2e 65 cc 11 07 00 04 00 00 05 ff 01 00 01
> > >     00
