### PR TITLE
Adding support for the new error codes returned by Facebook. 

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -41,8 +41,7 @@ class FacebookApiException extends Exception
    */
   public function __construct($result) {
     $this->result = $result;
-
-    $code = isset($result['error_code']) ? $result['error_code'] : (isset($result['error']) && isset($result['error']['code'])) ? $result['error']['code'] : 0;
+    $code = isset($result['error_code']) ? $result['error_code'] : 0;
 
     if (isset($result['error_description'])) {
       // OAuth 2.0 Draft 10 style
@@ -50,6 +49,9 @@ class FacebookApiException extends Exception
     } else if (isset($result['error']) && is_array($result['error'])) {
       // OAuth 2.0 Draft 00 style
       $msg = $result['error']['message'];
+      if (isset($result['error']['code'])) {
+         $code = $result['error']['code'];
+      }
     } else if (isset($result['error_msg'])) {
       // Rest server style
       $msg = $result['error_msg'];

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -390,7 +390,7 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     } catch(FacebookApiException $e) {
       // means the server got the access token and didn't like it
       $msg = 'OAuthException: Invalid OAuth access token.';
-      $this->assertEquals($msg, (string) $e,
+      $this->assertEquals($msg, (string) $e->getType().': '.$e->getMessage(),
                           'Expect the invalid OAuth token message.');
     }
   }
@@ -408,7 +408,7 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     } catch(FacebookApiException $e) {
       // means the server got the access token and didn't like it
       $error_msg_start = 'OAuthException: Error validating access token:';
-      $this->assertTrue(strpos((string) $e, $error_msg_start) === 0,
+      $this->assertTrue(strpos((string) $e->getType().': '.$e->getMessage(), $error_msg_start) === 0,
                         'Expect the token validation error message.');
     }
   }
@@ -428,7 +428,7 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
       // ProfileDelete means the server understood the DELETE
       $msg =
         'OAuthException: (#200) User cannot access this application';
-      $this->assertEquals($msg, (string) $e,
+      $this->assertEquals($msg, (string) $e->getType().': '.$e->getMessage(),
                           'Expect the invalid session message.');
     }
   }


### PR DESCRIPTION
One of the new error formats that facebook returns is like this: 

```
{
"error": {
    "message": "Error validating access token: The session has been invalidated because the user has changed the password.",
    "type": "OAuthException",
    "code": 190
    }
}
```

With Facebook PHP SDK you _can't_ execute **$ex->getCode()** because looks for `error_code` field only. I kept the original field but added support for the new format. 

Here https://developers.facebook.com/roadmap/ (Batch API Exception Format) you can find more information for the new format. It is implemented already for many Graph API endpoints.
