### PR TITLE
Fix SSL Timeouts

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -130,6 +130,7 @@ abstract class BaseFacebook
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_TIMEOUT        => 60,
     CURLOPT_USERAGENT      => 'facebook-php-3.1',
+    CURLOPT_SSLVERSION     => 3,
   );
 
   /**


### PR DESCRIPTION
If PHP is running with libcurl/7.25.0, trying to connect to the facebook API fails due to SSL timeouts. Setting CURLOPT_SSLVERSION = 3 fixes this and works with libcurl > 7.21.0
