### PR TITLE
added .travis.yml for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+script: phpunit --stderr --bootstrap tests/bootstrap.php tests/tests.php


### PR DESCRIPTION
I would propose adding .travis.yml for public continuous integration.

test suites of this repo seems ready for Travis environment.
http://travis-ci.org/#!/yandod/facebook-php-sdk/jobs/1102920

I'm sure running CI on public environment will show healthiness of sdk to all php developers.

Thanks.
