### PR TITLE
detect rest server styled errors

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -806,7 +806,7 @@ abstract class BaseFacebook
     ), true);
 
     // results are returned, errors are thrown
-    if (is_array($result) && isset($result['error'])) {
+    if (is_array($result) && (isset($result['error']) || isset($result['error_code']))) {
       $this->throwAPIException($result);
     }
 


### PR DESCRIPTION
Recently I start to receive eventually response from $facebook->api('/me') call as error array:

```
array (
    'error_code' => 1,
    'error_msg' => 'An unknown error occurred',
)
```

This response might easily break application w/o any reason, cause no exception was thrown.
FacebookApiException is able to handle this response, but it was not checked properly.
