### PR TITLE
Added support for 'expire' (which is sent by the Facebook API when a new access token is issued).

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -382,11 +382,12 @@ abstract class BaseFacebook
       // the JS SDK puts a code in with the redirect_uri of ''
       if (array_key_exists('code', $signed_request)) {
         $code = $signed_request['code'];
-        $access_token = $this->getAccessTokenFromCode($code, '');
-        if ($access_token) {
+        $params = $this->getAccessTokenFromCode($code, '');
+        if ($params) {
           $this->setPersistentData('code', $code);
-          $this->setPersistentData('access_token', $access_token);
-          return $access_token;
+          $this->setPersistentData('access_token', $params['access_token']);
+          $this->setPersistentData('access_token_expires', time() + $params['expires']);
+          return $params['access_token'];
         }
       }
 
@@ -399,11 +400,12 @@ abstract class BaseFacebook
 
     $code = $this->getCode();
     if ($code && $code != $this->getPersistentData('code')) {
-      $access_token = $this->getAccessTokenFromCode($code);
-      if ($access_token) {
+      $params = $this->getAccessTokenFromCode($code);
+      if ($params) {
         $this->setPersistentData('code', $code);
-        $this->setPersistentData('access_token', $access_token);
-        return $access_token;
+        $this->setPersistentData('access_token', $params['access_token']);
+        $this->setPersistentData('access_token_expires', time() + $params['expires']);
+        return $params['access_token'];
       }
 
       // code was bogus, so everything based on it should be invalidated.
@@ -690,8 +692,9 @@ abstract class BaseFacebook
    * either logged in to Facebook or has granted an offline access permission.
    *
    * @param string $code An authorization code.
-   * @return mixed An access token exchanged for the authorization code, or
-   *               false if an access token could not be generated.
+   * @return mixed An associate array: "access_token" = access token exchanged for the authorization code,
+   *                                   "expires" = seconds this token is valid,__PHP_Incomplete_Class
+   *               or false if an access token could not be generated.
    */
   protected function getAccessTokenFromCode($code, $redirect_uri = null) {
     if (empty($code)) {
@@ -728,7 +731,7 @@ abstract class BaseFacebook
       return false;
     }
 
-    return $response_params['access_token'];
+    return $response_params;
   }
 
   /**

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -40,7 +40,7 @@ class Facebook extends BaseFacebook
   }
 
   protected static $kSupportedKeys =
-    array('state', 'code', 'access_token', 'user_id');
+    array('state', 'code', 'access_token', 'access_token_expires', 'user_id');
 
   /**
    * Provides the implementations of the inherited abstract


### PR DESCRIPTION
The 'expire' field is sent when a new access token is issued. It reports how long this token remains valid. This change stores the point in time the access token will become stale. It stores it using setPersistentData('access_token_expires', value).

Note: the expire field is the number of seconds the new access token is valid. What we store however is time() + that value. We need to add the current point in time, because we loose that afterwards of course.
