### PR TITLE
Added ability to extend tokens

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -330,41 +330,46 @@ abstract class BaseFacebook
   }
 
   /**
-   * Extend an access token, while removing the short-lived token that might have been generated via client-side flow.
-   * Thanks to http://stackoverflow.com/questions/486896/adding-a-parameter-to-the-url-with-javascript for the workaround
+   * Extend an access token, while removing the short-lived token that might
+   * have been generated via client-side flow. Thanks to http://bit.ly/b0Pt0H
+   * for the workaround.
    */
-  public function getExtendedAccessToken() {
+  public function setExtendedAccessToken() {
     try {
       // need to circumvent json_decode by calling _oauthRequest
       // directly, since response isn't JSON format.
-      $access_token_response =
-        $this->_oauthRequest(
-          $this->getUrl('graph', '/oauth/access_token'),
-          $params = array(    'client_id' => $this->getAppId(),
+      $access_token_response = $this->_oauthRequest(
+        $this->getUrl('graph', '/oauth/access_token'),
+        $params = array(
+          'client_id' => $this->getAppId(),
           'client_secret' => $this->getAppSecret(),
-          'grant_type'=>'fb_exchange_token',
-          'fb_exchange_token'=>$this->getAccessToken(),
-        ));
-      } catch (FacebookApiException $e) {
-        // most likely that user very recently revoked authorization.
-        // In any event, we don't have an access token, so say so.
-        return false;
-      }
+          'grant_type' => 'fb_exchange_token',
+          'fb_exchange_token' => $this->getAccessToken(),
+        )
+      );
+    }
+    catch (FacebookApiException $e) {
+      // most likely that user very recently revoked authorization.
+      // In any event, we don't have an access token, so say so.
+      return false;
+    }
   
-      if (empty($access_token_response)) {
-        return false;
-      }
+    if (empty($access_token_response)) {
+      return false;
+    }
       
-      $response_params = array();
-      parse_str($access_token_response, $response_params);
-      
-      if (!isset($response_params['access_token'])) {
-        return false;
-      }
-      
-      $this->destroySession();
-      
-      $this->setPersistentData('access_token', $response_params['access_token']);
+    $response_params = array();
+    parse_str($access_token_response, $response_params);
+    
+    if (!isset($response_params['access_token'])) {
+      return false;
+    }
+    
+    $this->destroySession();
+    
+    $this->setPersistentData(
+      'access_token', $response_params['access_token']
+    );
   }
 
   /**


### PR DESCRIPTION
This adds the ability to get extended tokens.  Most folks use the JS client-side flow to auth users, which generates a short-lived token.

They can now call extendAccessToken() in order to get an long-lived token.

Note that this also destroys the original JS session, so some discussion may be needed as I don't know of any unintended consequences this could have.
