### PR TITLE
Setting Error code in FacebookAPIException

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -50,6 +50,7 @@ class FacebookApiException extends Exception
     } else if (isset($result['error']) && is_array($result['error'])) {
       // OAuth 2.0 Draft 00 style
       $msg = $result['error']['message'];
+      $code = isset($result['error']['code']) ? $result['error']['code'] : $code;
     } else if (isset($result['error_msg'])) {
       // Rest server style
       $msg = $result['error_msg'];


### PR DESCRIPTION
Right now the error code is not being set properly on this object when the response returns as OAuth 2.0 Draft 00 style.  Adding a line where, if the error code is set, it's passed properly to the Exception class on instantiation.  If not it falls back to the previous default.
