### PR TITLE
Adding check to make sure $code is an integer to avoid fatal error

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -57,6 +57,12 @@ class FacebookApiException extends Exception
       $msg = 'Unknown Error. Check getResult()';
     }
 
+    // need to make sure that $code is an int or
+    // this will throw a fatal error
+    if(!is_int($code)) {
+      $code = 0;
+    }
+    
     parent::__construct($msg, $code);
   }
 


### PR DESCRIPTION
I found this when I tried to install the Facebook WordPress plugin on a system that did not have the OpenSSL module installed.

I created a blog post about it here:
http://blog.robert.mcfrazier.com/facebook-wordpress-plugin-error-install/

The key thing is that $code did not have an integer value, and it was causing a fatal error, and that blocked access to the wordpress admin panel.  Even if you navigated to a different section on the admin panel, you would still see the fatal error for this plugin.  I had to fix this to get admin access back.
