### PR TITLE
ETags support

### DIFF
--- a/tests/tests.php
+++ b/tests/tests.php
@@ -953,6 +953,24 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
                        'Session superglobal incorrectly populated by getUser.');
   }
 
+  public function testETags() {
+    $facebook = new TransientFacebook(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+
+    $query = '/zuck';
+
+    $result = $facebook->api($query);
+    $etag = $facebook->getReceivedETag();
+
+    $facebook->setETag($etag);
+    $facebook->api($query);
+    $etag_hit = $facebook->isETagHit();
+
+    $this->assertTrue($etag_hit);
+  }
+
   public function testGetAccessTokenUsingCodeInJsSdkCookie() {
     $code = 'code1';
     $access_token = 'at1';


### PR DESCRIPTION
This PR adds ETag support. Example of usage:

``` php
$facebook = ...
$query = '/zuck';

// Get ETag for a query
$result = $facebook->api($query);
$etag = $facebook->getReceivedETag();

// Check if something has changed
$facebook->setETag($etag);
$facebook->api($query);
if ($facebook->isETagHit())
{
    // ETag has not changed
}
else
{
    // ETag has changed, save new:
    $new_etag = $facebook->getReceivedETag();
}
```

PS. Test case added in tests/tests.php (testETags).
