### PR TITLE
Get access token with a code set in the request as a fallback

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -391,10 +391,8 @@ abstract class BaseFacebook
       }
 
       // signed request states there's no access token, so anything
-      // stored should be cleared.
-      $this->clearAllPersistentData();
-      return false; // respect the signed request's data, even
-                    // if there's an authorization code or something else
+      // stored should be cleared even if the COOKIE put by JS SDK.
+      $this->destroySession();
     }
 
     $code = $this->getCode();


### PR DESCRIPTION
PHP SDK can not handle an authorizing code from a Facebook's auth dialog by right
in the case of the JavaScript SDK put a code in the COOKIE as a signed request.

Here is a repro:
1. First, set `fbsr_xxxxx` COOKIE with `FB.init()` of the JS SDK.
2. Wait a few minutes (enough to expire the authorize code of the SR in the COOKIE).
3. Request Facebook's auth dialog generated by `getLoginUrl()` method without using JS SDK just use only PHP SDK.
4. Click "Go to App" to install the app (This process is passed and just redirect back to my app when you already authorized).
5. Call `getAccessToken()` method in the page of returning back from Facebook,
   Then an endpoint of the authorize request `/oauth/access_token` returns "This authorization code has expired." even if the parameter `?code=xxxx` is set by Facebook.

PHP SDK deal in the COOKIE put by JavaScript SDK as a signed request,
can use the code set in the authorize process in `getUserAccessToken()`.

I know the comment,

> respect the signed request's data, even if there's an authorization code or something else

is in `getUserAccessToken()`, but this behavior is incompatible with the spec of collaborating with JS SDK.

Note: We have to call `destroySession()` to clear the old COOKIE so replace `clearAllPersistentData()` to `destroySession()`. The method `clearAllPersistentData()` sould clear the COOKIE if the COOKIE used like persistent data instead of the PHP session IMHO.
