### PR TITLE
Updated reference to amperstand in getURL method for w3c validation purposes

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1123,7 +1123,7 @@ abstract class BaseFacebook
       $url .= $path;
     }
     if ($params) {
-      $url .= '?' . http_build_query($params, null, '&');
+      $url .= '?' . http_build_query($params, null, '&amp;');
     }
 
     return $url;


### PR DESCRIPTION
I've updated the reference to an ampersand in the http_build_query function, part of the getUrl method. Updated from '&' to its HTML representation '&amp;'. This ensures W3C validation for login/logout links etc.
