### PR TITLE
Fix for multiple chained hosts in HTTP_X_FORWARDED_HOST, cURL proxy supoort

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -331,9 +331,9 @@ abstract class BaseFacebook
   }
 
   /**
-   * Sets the proxy to be used when doing http requests to the rmote servers
+   * Sets the proxy to be used when doing http requests to the remote servers
    *
-   * @param string $proxyUrl The procy URL string, including scheme, username,
+   * @param string $proxyUrl The proxy URL string, including scheme, username,
    *                         password or port
    * @return BaseFacebook
    */


### PR DESCRIPTION
This pull request contains:
- a small fix for the cases when there is more than one proxy, and HTTP_X_FORWARDED_HOST contains a comma separated list of all the proxy hosts the request was passed through; example: when the application is behind domainA.com and domainB.com,  HTTP_X_FORWARDED_HOST contains 'domainB.com, domainA.com'.
- added proxy support for accessing the remote Facebook API; some corporate servers are not directly exposed to the wild, but instead they must use internal proxies to access the web.
