### PR TITLE
Fix for sharedSession use and state initialization

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -215,6 +215,22 @@ abstract class BaseFacebook
   /**
    * Initialize a Facebook Application.
    *
+   * @param array $config The application configuration
+   */
+  public function __construct($config) {
+    // We update the configuration
+    $this->updateConfig($config);
+
+    // We get the state from persistent data
+    $state = $this->getPersistentData('state');
+    if (!empty($state)) {
+      $this->state = $state;
+    }
+  }
+
+  /**
+   * Update the Facebook configuration
+   *
    * The configuration:
    * - appId: the application ID
    * - secret: the application secret
@@ -222,7 +238,7 @@ abstract class BaseFacebook
    *
    * @param array $config The application configuration
    */
-  public function __construct($config) {
+  public function updateConfig($config) {
     $this->setAppId($config['appId']);
     $this->setAppSecret($config['secret']);
     if (isset($config['fileUpload'])) {

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -48,17 +48,13 @@ class Facebook extends BaseFacebook
     if (!session_id()) {
       session_start();
     }
-    parent::__construct($config);
     if (!empty($config['sharedSession'])) {
+      // We need the configuration for init shared session
+      $this->updateConfig($config);
       $this->initSharedSession();
-
-      // Now that shared session is initialized (with sharedSessionID from COOKIE if any)
-      // We try to get the state.
-      $state = $this->getPersistentData('state');
-      if (!empty($state)) {
-        $this->state = $state;
-      }
     }
+    // We call the default constructor
+    parent::__construct($config);
   }
 
   protected static $kSupportedKeys =


### PR DESCRIPTION
While trying to use the sharedSession attribute, I noticed that after a getLoginUrl, the state was stored in persistent data using the sharedSessionID.
After Oauth redirect, the state is checked before retrieving the code.
The state is initialized in Facebook constructor but currently before initSharedSession is called.
As the state is retrieved from persistent data, the sharedSession has to be initialized before.

I updated the code to fix this and have state correctly retrieved.
