### PR TITLE
@return documentation was incorrect for function

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -615,7 +615,7 @@ abstract class BaseFacebook
    * - no_user: the URL to go to if the user is not signed into facebook
    *
    * @param array $params Provide custom parameters
-   * @return string The URL for the logout flow
+   * @return string The URL for the login status flow
    */
   public function getLoginStatusUrl($params=array()) {
     return $this->getUrl(


### PR DESCRIPTION
getLoginStatusUrl @return documentation had been copied and pasted from another function. Just clearing it up for readers.
