### PR TITLE
Error code now correctly set in FacebookAPIException

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -50,7 +50,7 @@ class FacebookApiException extends Exception
     } else if (isset($result['error']) && is_array($result['error'])) {
       // OAuth 2.0 Draft 00 style
       $msg = $result['error']['message'];
-      $code = $result['error]['code'];
+      $code = $result['error']['code'];
     } else if (isset($result['error_msg'])) {
       // Rest server style
       $msg = $result['error_msg'];


### PR DESCRIPTION
Currently the error codes from Graph API calls do not get set in the FacebookApiException object because there is no 'error_code' in the error response.

I made it so that when it is in the "OAuth 2.0 Draft 00 style" block, it assigns $code the value of ['error']['code']. I do this because when ['error']['message'] exists, ['error']['code'] exists as well.
