### PR TITLE
Use `empty()` for signed request value check

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -483,10 +483,10 @@ abstract class BaseFacebook
    */
   public function getSignedRequest() {
     if (!$this->signedRequest) {
-      if (isset($_REQUEST['signed_request'])) {
+      if (!empty($_REQUEST['signed_request'])) {
         $this->signedRequest = $this->parseSignedRequest(
           $_REQUEST['signed_request']);
-      } else if (isset($_COOKIE[$this->getSignedRequestCookieName()])) {
+      } else if (!empty($_COOKIE[$this->getSignedRequestCookieName()])) {
         $this->signedRequest = $this->parseSignedRequest(
           $_COOKIE[$this->getSignedRequestCookieName()]);
       }

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -46,6 +46,10 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     return $facebook->publicMakeSignedRequest(array());
   }
 
+  private static function kSignedRequestWithEmptyValue() {
+    return '';
+  }
+
   private static function kSignedRequestWithBogusSignature() {
     $facebook = new FBPublic(array(
       'appId'  => self::APP_ID,
@@ -776,6 +780,18 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     $_REQUEST['signed_request'] = self::kNonTosedSignedRequest();
     $sr = $facebook->getSignedRequest();
     $this->assertTrue(isset($sr['algorithm']));
+  }
+
+  public function testSignedRequestWithEmptyValue() {
+    $fb = new FBPublicCookie(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET
+    ));
+    $_REQUEST['signed_request'] = self::kSignedRequestWithEmptyValue();
+    $this->assertNull($fb->getSignedRequest());
+    $_COOKIE[$fb->publicGetSignedRequestCookieName()] =
+      self::kSignedRequestWithEmptyValue();
+    $this->assertNull($fb->getSignedRequest());
   }
 
   public function testSignedRequestWithWrongAlgo() {


### PR DESCRIPTION
Use `!empty(...)` instead of `isset(...)` to check the signed request value inside the `getSignedRequest()` method.   This avoids trying to parse an empty signed request, and removes the not very accurate "Unknown algorithm. Expected HMAC-SHA256."  error from the logs. :) 

See: http://stackoverflow.com/questions/13535474/unknown-algorithm-expected-hmac-sha256-error-due-to-signed-request-cookie-bein
