### PR TITLE
checking if the session key exists before deleting it

### DIFF
--- a/src/facebook.php
+++ b/src/facebook.php
@@ -127,7 +127,9 @@ class Facebook extends BaseFacebook
     }
 
     $session_var_name = $this->constructSessionVariableName($key);
-    unset($_SESSION[$session_var_name]);
+    if (isset($_SESSION[$session_var_name])) {
+      unset($_SESSION[$session_var_name]);
+    }
   }
 
   protected function clearAllPersistentData() {


### PR DESCRIPTION
The session variables (for example 'state' and 'code') are not always saved yet in the session when trying to delete it.

In some use cases (such as the session manager in zend framework 2), the session is overriden by an arrayaccess object, causing a notice to be thrown when attempting to unset an un existing session variable.

This commit adds an "isset" check before the "unset".
