### PR TITLE
Add facebook.php symlink to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /coverage/
+# Ignore facebook.php symlink
+/facebook.php


### PR DESCRIPTION
This symlink is generated on deploy/vagrant init, and should be ignored by Git.
