### PR TITLE
Fixed a vulnerability with signed requests

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -529,6 +529,11 @@ abstract class BaseFacebook
     if ($signed_request) {
       if (array_key_exists('user_id', $signed_request)) {
         $user = $signed_request['user_id'];
+
+        if($user != $this->getPersistentData('user_id')){
+          $this->clearAllPersistentData();
+        }
+
         $this->setPersistentData('user_id', $signed_request['user_id']);
         return $user;
       }

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -22,18 +22,20 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
   const MIGRATED_APP_ID = '174236045938435';
   const MIGRATED_SECRET = '0073dce2d95c4a5c2922d1827ea0cca6';
 
-  const TEST_USER = 499834690;
+  const TEST_USER   = 499834690;
+  const TEST_USER_2 = 499835484;
 
   private static $kExpiredAccessToken = 'AAABrFmeaJjgBAIshbq5ZBqZBICsmveZCZBi6O4w9HSTkFI73VMtmkL9jLuWsZBZC9QMHvJFtSulZAqonZBRIByzGooCZC8DWr0t1M4BL9FARdQwPWPnIqCiFQ';
 
-  private static function kValidSignedRequest() {
+  private static function kValidSignedRequest($id = self::TEST_USER, $oauth_token = null) {
     $facebook = new FBPublic(array(
       'appId'  => self::APP_ID,
       'secret' => self::SECRET,
     ));
     return $facebook->publicMakeSignedRequest(
       array(
-        'user_id' => self::TEST_USER,
+        'user_id' => $id,
+        'oauth_token' => $oauth_token
       )
     );
   }
@@ -321,7 +323,6 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     // intentionally don't set CSRF token at all
     $this->assertFalse($facebook->publicGetCode(),
                        'Expect getCode to fail, CSRF state not sent back.');
-
   }
 
   public function testGetUserFromSignedRequest() {
@@ -333,6 +334,34 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     $_REQUEST['signed_request'] = self::kValidSignedRequest();
     $this->assertEquals('499834690', $facebook->getUser(),
                         'Failed to get user ID from a valid signed request.');
+  }
+
+  public function testSignedRequestRewrite(){
+    $facebook = new FBRewrite(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+
+    $_REQUEST['signed_request'] = self::kValidSignedRequest(self::TEST_USER, 'Hello sweetie');
+
+    $this->assertEquals(self::TEST_USER, $facebook->getUser(),
+                        'Failed to get user ID from a valid signed request.');
+
+    $this->assertEquals('Hello sweetie', $facebook->getAccessToken(),
+                        'Failed to get access token from signed request');
+
+    $facebook->uncache();
+
+    $_REQUEST['signed_request'] = self::kValidSignedRequest(self::TEST_USER_2, 'spoilers');
+
+    $this->assertEquals(self::TEST_USER_2, $facebook->getUser(),
+                        'Failed to get user ID from a valid signed request.');
+
+    $_REQUEST['signed_request'] = null;
+    $facebook ->uncacheSignedRequest();
+
+    $this->assertNotEquals('Hello sweetie', $facebook->getAccessToken(),
+                        'Failed to clear access token');
   }
 
   public function testGetSignedRequestFromCookie() {
@@ -1966,6 +1995,20 @@ class FBPublicCookie extends TransientFacebook {
 
   public function publicGetMetadataCookieName() {
     return $this->getMetadataCookieName();
+  }
+}
+
+class FBRewrite extends Facebook{
+
+  public function uncacheSignedRequest(){
+    $this->signedRequest = null;
+  }
+
+  public function uncache()
+  {
+    $this->user = null;
+    $this->signedRequest = null;
+    $this->accessToken = null;
   }
 }
 


### PR DESCRIPTION
See the next scenario.

1) Alice is logged into Facebook
2) Alice visits example.com/with_js_sdk.php (our PHP SDK example endpoint). The SDK will write her signed_request, user_id, and access_token to a session cookie.
3) Alice is then tricked into visiting example.com/with_js_sdk.php?signed_request={Bob's signed request}. The SDK will then set the user_id to Bob, while keeping Alice's access_token in persistent storage
4) If example.com has another endpoint that authenticates based on getUser(), Bob now has access to data returned by Alice's access_token.

This fixes it.
