### PR TITLE
Fix bug in CSRF state persistence when using shared sessions. 

### DIFF
--- a/src/facebook.php
+++ b/src/facebook.php
@@ -51,6 +51,16 @@ class Facebook extends BaseFacebook
     parent::__construct($config);
     if (!empty($config['sharedSession'])) {
       $this->initSharedSession();
+
+      // re-load the persisted state, since parent
+      // attempted to read out of non-shared cookie 
+      $state = $this->getPersistentData('state');
+      if (!empty($state)) {
+        $this->state = $state;
+      } else {
+        $this->state = null;
+      }
+ 
     }
   }
 

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -325,6 +325,45 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
                        'Expect getCode to fail, CSRF state not sent back.');
   }
 
+  public function testPersistentCSRFState()
+  {
+    $facebook = new FBCode(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    $facebook->setCSRFStateToken();
+    $code = $facebook->getCSRFStateToken();
+
+    $facebook = new FBCode(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+
+    $this->assertEquals($code, $facebook->publicGetState(),
+            'Persisted CSRF state token not loaded correctly');
+  }
+
+  public function testPersistentCSRFStateWithSharedSession()
+  {
+    $_SERVER['HTTP_HOST'] = 'fbrell.com';
+    $facebook = new FBCode(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+      'sharedSession' => true,
+    ));
+    $facebook->setCSRFStateToken();
+    $code = $facebook->getCSRFStateToken();
+
+    $facebook = new FBCode(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+      'sharedSession' => true,
+    ));
+
+    $this->assertEquals($code, $facebook->publicGetState(),
+            'Persisted CSRF state token not loaded correctly with shared session');
+  }
+
   public function testGetUserFromSignedRequest() {
     $facebook = new TransientFacebook(array(
       'appId'  => self::APP_ID,
@@ -1957,6 +1996,10 @@ class PersistentFBPublic extends Facebook {
 class FBCode extends Facebook {
   public function publicGetCode() {
     return $this->getCode();
+  }
+
+  public function publicGetState() {
+    return $this->state;
   }
 
   public function setCSRFStateToken() {


### PR DESCRIPTION
BaseFacebook loads the stored state in its constructor. However, at
that point, the shared session ID has not yet been initialized, so
getPersistentData() will return data from the non-shared-session cookie. Since
initSharedSession() depends upon state initialized in
BaseFacebook::__construct, just re-initialized the stored
state in the shared session situation.

Added appropriate tests to check CSRF state persistence with and without shared sessions.
