### PR TITLE
Add functionality to send batched requests to graph API

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1394,6 +1394,31 @@ abstract class BaseFacebook
   }
 
   /**
+   * Sends a batched request to the graph api
+   * @return retval - The response body
+   */
+  public function batch($data) {
+    $endpoint = self::$DOMAIN_MAP['graph'];
+
+    $payload = json_encode($data);
+
+    $post_data = array(
+      'access_token' => $this->getAccessToken(),
+      'batch' => $payload
+    );
+
+    $responses = json_decode($this->makeRequest($endpoint,$post_data),true);
+
+    $retval = array();
+
+    foreach($responses as $response) {
+      $retval[] = json_decode($response['body'],true);
+    }
+
+    return $retval;
+  }
+
+  /**
    * Each of the following four methods should be overridden in
    * a concrete subclass, as they are in the provided Facebook class.
    * The Facebook class uses PHP sessions to provide a primitive

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -493,6 +493,25 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
       $response['id'], '214707', 'should get expected id.');
   }
 
+  public function testBatchedAPIGraphCall() {
+    $facebook = new TransientFacebook(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET
+    ));
+
+    $batch_data = array(
+      array('method' => 'GET', 'relative_url' => 4),
+      array('method' => 'GET', 'relative_url' => 5)
+    );
+
+    $response = $facebook->batch($batch_data);
+    $this->assertEquals(2, count($response));
+    $this->assertEquals(4, $response[0]['id']);
+    $this->assertEquals(5, $response[1]['id']);
+    $this->assertEquals('zuck', $response[0]['username']);
+    $this->assertEquals('ChrisHughes', $response[1]['username']);
+  }
+
   public function testGraphAPIWithBogusAccessToken() {
     $facebook = new TransientFacebook(array(
       'appId'  => self::APP_ID,


### PR DESCRIPTION
When making multiple calls to the graph API, it is often handy to batch up the requests and make a single call.
This commit allows you to make calls like

``` php
$facebook = new Facebook(array(
  'appId'  => APP_ID,
  'secret' => SECRET
));

$batch_data = array(
  array('method' => 'GET', 'relative_url' => 4),
  array('method' => 'GET', 'relative_url' => 5)
);

$response = $facebook->batch($batch_data);

// Verify the response(s)
$this->assertEquals(2, count($response));
$this->assertEquals(4, $response[0]['id']);
$this->assertEquals(5, $response[1]['id']);
$this->assertEquals('zuck', $response[0]['username']);
$this->assertEquals('ChrisHughes', $response[1]['username']);

```
