### PR TITLE
Fix Remote Timing Attack vulnerability

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1021,7 +1021,7 @@ abstract class BaseFacebook
       $result |= ord($expected_sig[$i]) ^ ord($sig[$i]);
     }
 
-    if($result == 0) {
+    if ($result == 0) {
       return $data;
     } else {
       self::errorLog('Bad Signed JSON signature!');


### PR DESCRIPTION
The way the SDK compares the signed_request signature with the expected signature is vulnerable to a remote timing attack. For more information, see the following articles.

http://codahale.com/a-lesson-in-timing-attacks/
http://blog.astrumfutura.com/2010/10/nanosecond-scale-remote-timing-attacks-on-php-applications-time-to-take-them-seriously/
