### PR TITLE
Improved Open Graph support

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -848,6 +848,20 @@ abstract class BaseFacebook
   }
 
   /**
+   * Return true if this is a FQL query.
+   *
+   * @param string $path The path
+   *
+   * @return boolean true if this is a FQL query
+   */
+  protected function isFqlQuery($path) {
+    if (preg_match('/^(\/)?fql/', $path)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Invoke the Graph API.
    *
    * @param string $path The path (required)
@@ -870,9 +884,18 @@ abstract class BaseFacebook
       $domainKey = 'graph';
     }
 
+    // parameters must be encoded in JSON for FQL queries only
+    if ($this->isFqlQuery($path)) {
+        $queryParams = array();
+        $postParams = $params;
+    } else {
+        $queryParams = $params;
+        $postParams = array();
+    }
+
     $result = json_decode($this->_oauthRequest(
-      $this->getUrl($domainKey, $path),
-      $params
+      $this->getUrl($domainKey, $path, $queryParams),
+      $postParams
     ), true);
 
     // results are returned, errors are thrown
@@ -895,7 +918,7 @@ abstract class BaseFacebook
    * @throws FacebookApiException
    */
   protected function _oauthRequest($url, $params) {
-    if (!isset($params['access_token'])) {
+    if (!isset($params['access_token']) && strpos($url, 'access_token') === false) {
       $params['access_token'] = $this->getAccessToken();
     }
 
@@ -1456,3 +1479,5 @@ abstract class BaseFacebook
    */
   abstract protected function clearAllPersistentData();
 }
+
+

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -1433,7 +1433,7 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     $stub->api(array('method' => 'foo'));
   }
 
-  public function testJsonEncodeOfNonStringParams() {
+  public function testNonStringParams() {
     $foo = array(1, 2);
     $params = array(
       'method' => 'get',
@@ -1445,7 +1445,26 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     ));
     $fb->api('/naitik', $params);
     $requests = $fb->publicGetRequests();
-    $this->assertEquals(json_encode($foo), $requests[0]['params']['foo']);
+    $expectedResult = http_build_query(array('foo' => $foo), null, '&');
+    $this->assertContains($expectedResult, $requests[0]['url']);
+  }
+
+  public function testMultiFqlQueryParams() {
+    $queries = array(
+        'first_name' => 'SELECT first_name FROM user WHERE uid = 4',
+        'last_name' => 'SELECT last_name FROM user WHERE uid = 4',
+    );
+    $params = array(
+      'method' => 'get',
+      'q' => $queries
+    );
+    $fb = new FBRecordMakeRequest(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    $fb->api('/fql', $params);
+    $requests = $fb->publicGetRequests();
+    $this->assertEquals(json_encode($queries), $requests[0]['params']['q']);
   }
 
   public function testSessionBackedFacebook() {
@@ -2032,3 +2051,4 @@ class FBPublicState extends TransientFacebook {
     return $this->state;
   }
 }
+


### PR DESCRIPTION
The `api` method currently encode in Json arrays passed as parameters. This produces errors when trying to send user generated photos :

> (#3503) *Json string* is an invalid value for property "image:url" with type "URL" 

or when tagging people :

> (#100) param tags must be an array.

As far as I know only FQL queries need to be encoded in Json. So with this pull request arrays are only encoded in Json when this is a FQL query. 
