### PR TITLE
Added CURL options configuration for user defined CURL settings.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -213,6 +213,13 @@ abstract class BaseFacebook
   protected $trustForwarded = false;
 
   /**
+   * User defined CURL options
+   *
+   * @var  array
+   */
+  protected $curlOptions = array();
+
+  /**
    * Initialize a Facebook Application.
    *
    * The configuration:
@@ -230,6 +237,9 @@ abstract class BaseFacebook
     }
     if (isset($config['trustForwarded']) && $config['trustForwarded']) {
       $this->trustForwarded = true;
+    }
+    if (isset($config['curlOptions']) and is_array($config['curlOptions'])) {
+      $this->setCurlOptions($config['curlOptions']);
     }
     $state = $this->getPersistentData('state');
     if (!empty($state)) {
@@ -328,6 +338,28 @@ abstract class BaseFacebook
    */
   public function useFileUploadSupport() {
     return $this->getFileUploadSupport();
+  }
+
+  /**
+   * Set user defined CURL options for api calls.
+   *
+   * @param array $options user defined CURL options
+   * @return BaseFacebook
+   */
+  public function setCurlOptions(array $options)
+  {
+    $this->curlOptions = $options;
+    return $this;
+  }
+
+  /**
+   * Get user defined CURL options.
+   *
+   * @return array CURL options
+   */
+  public function getCurlOptions()
+  {
+    return $this->curlOptions;
   }
 
   /**
@@ -925,7 +957,7 @@ abstract class BaseFacebook
       $ch = curl_init();
     }
 
-    $opts = self::$CURL_OPTS;
+    $opts = $this->curlOptions + self::$CURL_OPTS;
     if ($this->getFileUploadSupport()) {
       $opts[CURLOPT_POSTFIELDS] = $params;
     } else {

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -105,6 +105,26 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
                       'Expect file upload support to be on.');
   }
 
+  public function testConstructorCurlOptions() {
+
+    $curlOptions = array(
+      CURLOPT_PROXY => '123.123.123.123',
+    );
+
+    $facebook = new TransientFacebook(array(
+      'appId'      => self::APP_ID,
+      'secret'     => self::SECRET,
+      'curlOptions' => $curlOptions,
+    ));
+
+    $this->assertEquals($facebook->getAppId(), self::APP_ID,
+                        'Expect the App ID to be set.');
+    $this->assertEquals($facebook->getAppSecret(), self::SECRET,
+                        'Expect the API secret to be set.');
+    $this->assertEquals($curlOptions, $facebook->getCurlOptions(),
+                        'Expect the CURL options to be set.');
+  }
+
   public function testSetAppId() {
     $facebook = new TransientFacebook(array(
       'appId'  => self::APP_ID,


### PR DESCRIPTION
In a recent project I had to use the Facebook PHP SDK through a proxy due to very tightly set security measures. I had to hack in into the class itself, but that's no really nice. I've added a new configuration option that would allow for users to define extra CURL options. Tests are included as well.
