### PR TITLE
Update base_facebook.php

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -841,7 +841,7 @@ abstract class BaseFacebook
    * @return boolean true if this is video post
    */
   protected function isVideoPost($path, $method = 'GET') {
-    if ($method == 'POST' && preg_match("/^(\/)(.+)(\/)(videos)$/", $path)) {
+    if ($method == 'POST' && preg_match("/^(\\/)(.+)(\\/)(videos)$/", $path)) {
       return true;
     }
     return false;


### PR DESCRIPTION
In PHP string literals, the backslash (\) is used as an escape character. To write an actual backslash, a double backslash should be used (\\). This does not fix any problem since PHP defaults to a normal backslash when the escape sequence is illegal (eg: \/), but of course it is bad practice to rely on this behaviour.
