### PR TITLE
Use OS-specific directory separator instead of hard-coded forward slash

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -967,7 +967,7 @@ abstract class BaseFacebook
       self::errorLog('Invalid or no certificate authority found, '.
                      'using bundled information');
       curl_setopt($ch, CURLOPT_CAINFO,
-                  dirname(__FILE__) . '/fb_ca_chain_bundle.crt');
+                  dirname(__FILE__) . DIRECTORY_SEPARATOR . 'fb_ca_chain_bundle.crt');
       $result = curl_exec($ch);
     }
 


### PR DESCRIPTION
Fix issue with cURL on Windows machines when the local CA cert file 
is used. For some reason cURL refuses to use the CA cert bundle if 
forward-slashes are present in its path name.
