### PR TITLE
Changed FacebookBase::errorLog to a non-static method

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -698,7 +698,7 @@ abstract class BaseFacebook
         $this->clearPersistentData('state');
         return $_REQUEST['code'];
       } else {
-        self::errorLog('CSRF state token does not match one provided.');
+        $this->errorLog('CSRF state token does not match one provided.');
         return false;
       }
     }
@@ -964,7 +964,7 @@ abstract class BaseFacebook
     $result = curl_exec($ch);
 
     if (curl_errno($ch) == 60) { // CURLE_SSL_CACERT
-      self::errorLog('Invalid or no certificate authority found, '.
+      $this->errorLog('Invalid or no certificate authority found, '.
                      'using bundled information');
       curl_setopt($ch, CURLOPT_CAINFO,
                   dirname(__FILE__) . '/fb_ca_chain_bundle.crt');
@@ -981,7 +981,7 @@ abstract class BaseFacebook
         $regex = '/Failed to connect to ([^:].*): Network is unreachable/';
         if (preg_match($regex, curl_error($ch), $matches)) {
           if (strlen(@inet_pton($matches[1])) === 16) {
-            self::errorLog('Invalid IPv6 configuration on server, '.
+            $this->errorLog('Invalid IPv6 configuration on server, '.
                            'Please disable or get native IPv6 on your server.');
             self::$CURL_OPTS[CURLOPT_IPRESOLVE] = CURL_IPRESOLVE_V4;
             curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
@@ -1019,7 +1019,7 @@ abstract class BaseFacebook
     $data = json_decode(self::base64UrlDecode($payload), true);
 
     if (strtoupper($data['algorithm']) !== self::SIGNED_REQUEST_ALGORITHM) {
-      self::errorLog(
+      $this->errorLog(
         'Unknown algorithm. Expected ' . self::SIGNED_REQUEST_ALGORITHM);
       return null;
     }
@@ -1028,7 +1028,7 @@ abstract class BaseFacebook
     $expected_sig = hash_hmac('sha256', $payload,
                               $this->getAppSecret(), $raw = true);
     if ($sig !== $expected_sig) {
-      self::errorLog('Bad Signed JSON signature!');
+      $this->errorLog('Bad Signed JSON signature!');
       return null;
     }
 
@@ -1295,7 +1295,7 @@ abstract class BaseFacebook
    *
    * @param string $msg Log message
    */
-  protected static function errorLog($msg) {
+  protected function errorLog($msg) {
     // disable error log if we are running in a CLI environment
     // @codeCoverageIgnoreStart
     if (php_sapi_name() != 'cli') {
@@ -1354,7 +1354,7 @@ abstract class BaseFacebook
         setcookie($cookie_name, '', 1, '/', '.'.$base_domain);
       } else {
         // @codeCoverageIgnoreStart
-        self::errorLog(
+        $this->errorLog(
           'There exists a cookie that we wanted to clear that we couldn\'t '.
           'clear because headers was already sent. Make sure to do the first '.
           'API call before outputing anything.'

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -84,7 +84,7 @@ class Facebook extends BaseFacebook
       setcookie($cookie_name, $cookie_value, $expire, '/', '.'.$base_domain);
     } else {
       // @codeCoverageIgnoreStart
-      self::errorLog(
+      $this->errorLog(
         'Shared session ID cookie could not be set! You must ensure you '.
         'create the Facebook instance before headers have been sent. This '.
         'will cause authentication issues after the first request.'
@@ -101,7 +101,7 @@ class Facebook extends BaseFacebook
    */
   protected function setPersistentData($key, $value) {
     if (!in_array($key, self::$kSupportedKeys)) {
-      self::errorLog('Unsupported key passed to setPersistentData.');
+      $this->errorLog('Unsupported key passed to setPersistentData.');
       return;
     }
 
@@ -111,7 +111,7 @@ class Facebook extends BaseFacebook
 
   protected function getPersistentData($key, $default = false) {
     if (!in_array($key, self::$kSupportedKeys)) {
-      self::errorLog('Unsupported key passed to getPersistentData.');
+      $this->errorLog('Unsupported key passed to getPersistentData.');
       return $default;
     }
 
@@ -122,7 +122,7 @@ class Facebook extends BaseFacebook
 
   protected function clearPersistentData($key) {
     if (!in_array($key, self::$kSupportedKeys)) {
-      self::errorLog('Unsupported key passed to clearPersistentData.');
+      $this->errorLog('Unsupported key passed to clearPersistentData.');
       return;
     }
 

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -1804,6 +1804,16 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     );
   }
 
+  public function testErrorLogOverride() {
+    $fb = new FBCaptureErrorLog(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET
+    ));
+    $this->assertEmpty($fb->errorLog);
+    $fb->publicParseSignedRequest(self::kSignedRequestWithWrongAlgo());
+    $this->assertNotEmpty($fb->errorLog);
+  }
+
   public function provideIsAllowedDomain() {
     return array(
       array('fbrell.com', 'fbrell.com', true),
@@ -2030,5 +2040,12 @@ class FBPublicState extends TransientFacebook {
 
   public function publicGetState() {
     return $this->state;
+  }
+}
+
+class FBCaptureErrorLog extends FBPublic {
+  public $errorLog = array();
+  protected function errorLog($msg) {
+    $this->errorLog[] = $msg;
   }
 }


### PR DESCRIPTION
Changed `FacebookBase::errorLog` to a non-static method so that it may be overridden by subclasses. Although this method has been marked as protected, it was never possible to override its functionality through subclassing because references to it were made with non static binding `self::`. Rather than changing these references to `static::` and breaking compatibility with php 5.2, I've chosen to remove the static qualifier from the method.

All references have been updated from `self::errorLog(...` to `$this->errorLog(...`
The unit test `testErrorLogOverride` has been added to ensure that error logging behavior can be overridden by subclass.
