### PR TITLE
Check if headers have been sent before starting a session to prevent warning messages.

### DIFF
--- a/src/facebook.php
+++ b/src/facebook.php
@@ -45,7 +45,7 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::__construct in facebook.php
    */
   public function __construct($config) {
-    if (!session_id()) {
+    if (!headers_sent() && !session_id()) {
       session_start();
     }
     parent::__construct($config);


### PR DESCRIPTION
When running PHPUnit on my project the following exception is thrown:

session_start(): Cannot send session cookie - headers already sent by (output started at /usr/local/php5/lib/php/PHPUnit/Util/Printer.php:172)

file: .../vendor/facebook/php-sdk/src/facebook.php on line: 49
