### PR TITLE
Delayed reading from the persistent storage until actually needed

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -191,6 +191,13 @@ abstract class BaseFacebook
   protected $state;
 
   /**
+   * Whether the state has been read from the persistent storage.
+   *
+   * @var boolean
+   */
+  protected $initialized = false;
+
+  /**
    * The OAuth access token received in exchange for a valid authorization
    * code.  null means the access token has yet to be determined.
    *
@@ -231,10 +238,29 @@ abstract class BaseFacebook
     if (isset($config['trustForwarded']) && $config['trustForwarded']) {
       $this->trustForwarded = true;
     }
-    $state = $this->getPersistentData('state');
-    if (!empty($state)) {
-      $this->state = $state;
+  }
+
+  /**
+   * @return string|null
+   */
+  protected function getState() {
+    if (! $this->initialized) {
+        $state = $this->getPersistentData('state');
+        if (!empty($state)) {
+            $this->state = $state;
+        }
+        $this->initialized = true;
     }
+
+    return $this->state;
+  }
+
+  /**
+   * @param string|null $state
+   */
+  protected function setState($state) {
+    $this->state = $state;
+    $this->initialized = true;
   }
 
   /**
@@ -592,7 +618,7 @@ abstract class BaseFacebook
       array_merge(array(
                     'client_id' => $this->getAppId(),
                     'redirect_uri' => $currentUrl, // possibly overwritten
-                    'state' => $this->state),
+                    'state' => $this->getState()),
                   $params));
   }
 
@@ -689,12 +715,13 @@ abstract class BaseFacebook
    */
   protected function getCode() {
     if (isset($_REQUEST['code'])) {
-      if ($this->state !== null &&
+      $state = $this->getState();
+      if ($state !== null &&
           isset($_REQUEST['state']) &&
-          $this->state === $_REQUEST['state']) {
+          $state === $_REQUEST['state']) {
 
         // CSRF state has done its job, so clear it
-        $this->state = null;
+        $this->setState(null);
         $this->clearPersistentData('state');
         return $_REQUEST['code'];
       } else {
@@ -742,9 +769,10 @@ abstract class BaseFacebook
    * @return void
    */
   protected function establishCSRFTokenState() {
-    if ($this->state === null) {
-      $this->state = md5(uniqid(mt_rand(), true));
-      $this->setPersistentData('state', $this->state);
+    if ($this->getState() === null) {
+      $state = md5(uniqid(mt_rand(), true));
+      $this->setState($state);
+      $this->setPersistentData('state', $state);
     }
   }
 

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -2029,6 +2029,6 @@ class FBPublicState extends TransientFacebook {
   }
 
   public function publicGetState() {
-    return $this->state;
+    return $this->getState();
   }
 }


### PR DESCRIPTION
The current implementation of `BaseFacebook::__construct()` reads a value from the persistent storage.

This might not be a problem with the default `Facebook` class, which relies on the PHP session storage, which is always available.

However, having subclassed `BaseFacebook` myself to support a homebrew persistent storage system (we don't use PHP's `$_SESSION`), I ran into the following problems:
- When I instantiate (actually, when my Dependency Injection framework instantiates) a service that has a dependency on Facebook, a variable is read from the storage, even if no subsequent methods are called on the Facebook class. This is a waste of resources.
- When I run my tests, or CLI tools, sometimes I also need an instante of a Service that has a dependency on Facebook, even though I will never actually use something that makes a call to the Facebook class. In my CLI tools, no session is started, and therefore Facebook makes everything fail.

This PR fixes this, by delaying the read of the `state` variable until it is actually needed.
