### PR TITLE
Added PHPUnit as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /coverage/
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "ext-curl": "*",
         "ext-json": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "*"
+    },
     "autoload": {
         "classmap": ["src"]
     }

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ test case.
 
 The tests can be executed by using this command from the base directory:
 
-    phpunit --stderr --bootstrap tests/bootstrap.php tests/tests.php
+    vendor/bin/phpunit --stderr --bootstrap tests/bootstrap.php tests/tests.php
 
 
 Contributing


### PR DESCRIPTION
The current version of the SDK assumes that you have PHPUnit installed globally, which is not always the case.

This PR adds PHPUnit as a Composer _dev_ dependency (this means it won't be installed unless running `composer install --dev`), allowing to run PHPUnit from the `vendor/bin` directory (updated the README to reflect this).

This is a pretty standard practice in PHP libraries.
