### PR TITLE
missing setAccessToken

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -381,6 +381,7 @@ abstract class BaseFacebook
 
     $this->destroySession();
 
+    $this->setAccessToken($response_params['access_token']);
     $this->setPersistentData(
       'access_token', $response_params['access_token']
     );


### PR DESCRIPTION
This missing line was causing problem when used with the following scenario:

``` php
$facebookAdapter->getAccessToken();
//[...] some actions
$facebookAdapter->setExtendedAccessToken();
$facebookAdapter->getAccessToken();
```

there was an error

```
{"error":{"message":"Error validating verification code. Please make sure your redirect_uri is identical to the one you used in the OAuth dialog request","type":"OAuthException","code":100}}
```

Why? 
Because here:
https://github.com/facebook/facebook-php-sdk/blob/master/src/base_facebook.php#L382
session is destroyed.

and then here:
https://github.com/facebook/facebook-php-sdk/blob/master/src/base_facebook.php#L399
cached version of access token is not returned.

And then there is a request to exchange code to access token, but our code is already expired.

This problem exists when we already passed the facebook authentication process and our url is like this:

```
http://example.com?code=CODE&state=STATE#_=_
```
