### PR TITLE
Added a new BaseFacebook::disableAppSecretProof() method to stop sending...

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -213,6 +213,13 @@ abstract class BaseFacebook
   protected $trustForwarded = false;
 
   /**
+   * Indicates whether the appsecret_proof parameter should be
+   * sent with every request.
+   * @var boolean
+   */
+  protected $disableAppSecretProof = false;
+
+  /**
    * Initialize a Facebook Application.
    *
    * The configuration:
@@ -341,6 +348,15 @@ abstract class BaseFacebook
   public function setAccessToken($access_token) {
     $this->accessToken = $access_token;
     return $this;
+  }
+
+  /**
+   * Prevent the appsecret_proof parameter to be sent with api calls.
+   * This must be used only with the 'Require AppSecret Proof for
+   * Server API calls' app setting set to 'Disabled'.
+   */
+  public function disableAppSecretProof() {
+    $this->disableAppSecretProof = true;
   }
 
   /**
@@ -899,7 +915,7 @@ abstract class BaseFacebook
       $params['access_token'] = $this->getAccessToken();
     }
 
-    if (isset($params['access_token'])) {
+    if (!$this->disableAppSecretProof && isset($params['access_token'])) {
       $params['appsecret_proof'] = $this->getAppSecretProof($params['access_token']);
     }
 

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -621,6 +621,21 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
                        'available with a valid access token.');
   }
 
+  public function testDisableAppSecretProof() {
+    $facebook = new FBRecordMakeRequest(array(
+        'appId'  => self::APP_ID,
+        'secret' => self::SECRET,
+    ));
+    $facebook->disableAppSecretProof();
+    $facebook->api('/jerry');
+    $requests = $facebook->publicGetRequests();
+    $this->assertTrue(count($requests) > 0, 'Expected at least a request');
+    foreach($requests as $request) {
+      $params = $request['params'];
+      $this->assertFalse(array_key_exists('appsecret_proof', $params), 'appsecret_proof parameter shouldn\'t be there');
+    }
+  }
+
   public function testLoginURLDefaults() {
     $_SERVER['HTTP_HOST'] = 'fbrell.com';
     $_SERVER['REQUEST_URI'] = '/examples';


### PR DESCRIPTION
... the appsecret_proof parameters with the requests. This should be used only with the 'Require AppSecret Proof for Server API calls' app setting set to 'Disabled'.

Prior to this change, even though the 'Require AppSecret Proof for Server API calls' app setting was set to 'Disabled', the appsecret_proof parameter was still sent by the SDK and checked by the server.
