### PR TITLE
Make getLoginStatusUrl use /dialog/oauth

### DIFF
--- a/examples/example.php
+++ b/examples/example.php
@@ -46,6 +46,7 @@ if ($user) {
 if ($user) {
   $logoutUrl = $facebook->getLogoutUrl();
 } else {
+  $statusUrl = $facebook->getLoginStatusUrl();
   $loginUrl = $facebook->getLoginUrl();
 }
 
@@ -76,6 +77,10 @@ $naitik = $facebook->api('/naitik');
     <?php if ($user): ?>
       <a href="<?php echo $logoutUrl; ?>">Logout</a>
     <?php else: ?>
+      <div>
+        Check the login status using OAuth 2.0 handled by the PHP SDK:
+        <a href="<?php echo $statusUrl; ?>">Check the login status</a>
+      </div>
       <div>
         Login using OAuth 2.0 handled by the PHP SDK:
         <a href="<?php echo $loginUrl; ?>">Login with Facebook</a>

--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -589,11 +589,15 @@ abstract class BaseFacebook
     return $this->getUrl(
       'www',
       'dialog/oauth',
-      array_merge(array(
-                    'client_id' => $this->getAppId(),
-                    'redirect_uri' => $currentUrl, // possibly overwritten
-                    'state' => $this->state),
-                  $params));
+      array_merge(
+        array(
+          'client_id' => $this->getAppId(),
+          'redirect_uri' => $currentUrl, // possibly overwritten
+          'state' => $this->state,
+          'sdk' => 'php-sdk-'.self::VERSION
+        ),
+        $params
+      ));
   }
 
   /**
@@ -619,24 +623,14 @@ abstract class BaseFacebook
   /**
    * Get a login status URL to fetch the status from Facebook.
    *
-   * The parameters:
-   * - ok_session: the URL to go to if a session is found
-   * - no_session: the URL to go to if the user is not connected
-   * - no_user: the URL to go to if the user is not signed into facebook
-   *
    * @param array $params Provide custom parameters
    * @return string The URL for the logout flow
    */
   public function getLoginStatusUrl($params=array()) {
-    return $this->getUrl(
-      'www',
-      'extern/login_status.php',
+    return $this->getLoginUrl(
       array_merge(array(
-        'api_key' => $this->getAppId(),
-        'no_session' => $this->getCurrentUrl(),
-        'no_user' => $this->getCurrentUrl(),
-        'ok_session' => $this->getCurrentUrl(),
-        'session_version' => 3,
+        'response_type' => 'code',
+        'display' => 'none',
       ), $params)
     );
   }


### PR DESCRIPTION
To make this a drop in replacement for the old endpoint, we also need
support from the /dialog/oauth endpoint. Specifically, the current
endpoint, when using display=none, always return the response as part of
the fragment, while the PHP SDK needs the signed_request as a query
string argument.
