### PR TITLE
Check isset before unset

### DIFF
--- a/src/facebook.php
+++ b/src/facebook.php
@@ -127,7 +127,9 @@ class Facebook extends BaseFacebook
     }
 
     $session_var_name = $this->constructSessionVariableName($key);
-    unset($_SESSION[$session_var_name]);
+    if (isset($_SESSION[$session_var_name])) {
+      unset($_SESSION[$session_var_name]);
+    }
   }
 
   protected function clearAllPersistentData() {


### PR DESCRIPTION
Before accessing any index keys, it's recommended and strict to check if it is set.  PHP logs a notice when you do not.  This is to resolve PR #53. 
