### PR TITLE
Added setSignedRequest method

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -502,6 +502,29 @@ abstract class BaseFacebook
   }
 
   /**
+   * Parse and set the given signed request
+   *
+   * @param string $rawSignedRequest The raw signed request string
+   *
+   * @return boolean true if successfully parsed & set the given signed request
+   */
+  public function setSignedRequest($rawSignedRequest) {
+
+    // Make sure the given signed request string have a '.' in it to avoid missing $payload on self::parseSignedRequest
+    if (strpos($rawSignedRequest, '.') === false) {
+      return false;
+    }
+
+    if (($signedRequest = $this->parseSignedRequest($rawSignedRequest)) === null) {
+      return false;
+    }
+
+    $this->signedRequest = $signedRequest;
+
+    return true;
+  }
+
+  /**
    * Get the UID of the connected user, or 0
    * if the Facebook user is not connected.
    *

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -40,6 +40,14 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     );
   }
 
+  private static function kValidSignedRequestArray(array $data) {
+    $facebook = new FBPublic(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    return $facebook->publicMakeSignedRequest($data);
+  }
+
   private static function kNonTosedSignedRequest() {
     $facebook = new FBPublic(array(
       'appId'  => self::APP_ID,
@@ -401,6 +409,32 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
 
     $this->assertNotEquals('Hello sweetie', $facebook->getAccessToken(),
                         'Failed to clear access token');
+  }
+
+  public function testSetSigedRequest() {
+    $facebook = new Facebook(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    $this->assertFalse($facebook->setSignedRequest('Some not valid signed request string'),
+                                                   'setSignedRequest should fail when parseSignedRequest fails');
+
+    $signedRequestData = [
+      'user_id'     => self::TEST_USER,
+      'oauth_token' => 'Don\'t look!',
+      'code'        => 'some arbitrary code'
+    ];
+    $facebook = new Facebook(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    $facebook->setSignedRequest(self::kValidSignedRequestArray($signedRequestData));
+    $signedRequestOutData = $facebook->getSignedRequest();
+
+    // Ignore values added internally
+    unset($signedRequestOutData['algorithm'], $signedRequestOutData['issued_at']);
+    $this->assertEquals($signedRequestOutData, $signedRequestData,
+                        'Signed request data is different from the The data injected via setSignedRequest');
   }
 
   public function testGetSignedRequestFromCookie() {


### PR DESCRIPTION
Gives the developer more control if to let the SDK look for a signed request in the REQUEST/COOKIE arrays
or supply it explicitly
