### PR TITLE
Turn parseSignedRequest method into public

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1006,7 +1006,12 @@ abstract class BaseFacebook
    * @param string $signed_request A signed token
    * @return array The payload inside it or null if the sig is wrong
    */
-  protected function parseSignedRequest($signed_request) {
+  public function parseSignedRequest($signed_request) {
+    if (strpos($signed_request, '.') === false) {
+      self::errorLog('Malformed signed request');
+      return null;
+    }
+
     list($encoded_sig, $payload) = explode('.', $signed_request, 2);
 
     // decode the data


### PR DESCRIPTION
- Make sure we won't get a php error when the signed request string is mission "."
