### PR TITLE
Improved validation in parseSignedRequest.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1007,13 +1007,21 @@ abstract class BaseFacebook
    * @return array The payload inside it or null if the sig is wrong
    */
   protected function parseSignedRequest($signed_request) {
+
+    if (!$signed_request || strpos($signed_request, '.') === false) {
+        self::errorLog('Signed request was invalid!');
+        return null;
+    }
+
     list($encoded_sig, $payload) = explode('.', $signed_request, 2);
 
     // decode the data
     $sig = self::base64UrlDecode($encoded_sig);
     $data = json_decode(self::base64UrlDecode($payload), true);
 
-    if (strtoupper($data['algorithm']) !== self::SIGNED_REQUEST_ALGORITHM) {
+    if (!isset($data['algorithm'])
+        || strtoupper($data['algorithm']) !==  self::SIGNED_REQUEST_ALGORITHM
+    ) {
       self::errorLog(
         'Unknown algorithm. Expected ' . self::SIGNED_REQUEST_ALGORITHM);
       return null;


### PR DESCRIPTION
Several prior PRs referenced this.  I researched other open source implementations and this is common first line of defense.  Also added an isset check on the decoded signature.

It's not easily testable since the method is private, but if necessary, a full network test can be added.  The tests that do hit the network validate that this doesn't break correct requests.
