### PR TITLE
Added validation and test for non-int error_code defaulting to 0.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -42,7 +42,10 @@ class FacebookApiException extends Exception
   public function __construct($result) {
     $this->result = $result;
 
-    $code = isset($result['error_code']) ? $result['error_code'] : 0;
+    $code = 0;
+    if (isset($result['error_code']) && is_int($result['error_code'])) {
+      $code = $result['error_code'];
+    }
 
     if (isset($result['error_description'])) {
       // OAuth 2.0 Draft 10 style

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -1350,6 +1350,11 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     $this->assertEquals($code, $e->getCode());
   }
 
+  public function testExceptionConstructorWithInvalidErrorCode() {
+    $e = new FacebookApiException(array('error_code' => 'not an int'));
+    $this->assertEquals(0, $e->getCode());
+  }
+
   // this happens often despite the fact that it is useless
   public function testExceptionTypeFalse() {
     $e = new FacebookApiException(false);


### PR DESCRIPTION
Related to PR #29, this will add some validation and a test to ensure the error_code for a FacebookApiException is an integer value.
