### PR TITLE
Support for multiple chained forward proxies in getHttpHost()

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1183,8 +1183,9 @@ abstract class BaseFacebook
   protected function getHttpHost() {
     if ($this->trustForwarded && isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
       $forwardProxies = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
-      $forwardProxies = array_filter($forwardProxies);
-      return current($forwardProxies);
+      if (!empty($forwardProxies)) {
+        return $forwardProxies[0];
+      }
     }
     return $_SERVER['HTTP_HOST'];
   }


### PR DESCRIPTION
When the application that uses the Facebook PHP SDK is behind 2 or more forward proxies, the **X-Forwarded-Host** header contains a comma separated list of hosts (each proxy appends a comma and its own hostname).

For example, if we have this chain:

```
        Client
            |
        Fwd Proxy1 (first.proxy)
            |
        Fwd Proxy2 (second.proxy )
            |
        Application (third.server) 
```

Then we will have these values for a script executed on third.server:

``` php
    $_SERVER['HTTP_X_FORWARDED_HOST'] = 'first.proxy, second.proxy';
    $_SERVER['HTTP_HOST'] = 'third.server';
```

If we use the raw value from **$_SERVER['HTTP_X_FORWARDED_HOST']** for composing return URLs, we will generate invalid return URLs, in our case: **[http://first.proxy, second.proxy/fb_oauth.php](http://first.proxy, second.proxy/fb_oauth.php)**, and of course, we get a **'Oauth exception 191'** or some other error message.

If we properly process the X-Forwarded-Host value by taking the **leftmost** host, we will not get errors.
To test this, you can simulate the setup locally with Apache and mod_proxy/mod_proxy_http:
1. Add '127.0.0.1 first.proxy second.proxy third.server' to your /etc/hosts
2. Setup the vhosts:

```
    <VirtualHost *:80>
      ServerName       first.proxy
      ProxyPass        / http://second.proxy/
      ProxyPassReverse / http://second.proxy/
    </VirtualHost>

    <VirtualHost *:80>
      ServerName       second.proxy
      ProxyPass        / http://third.server/
      ProxyPassReverse / http://third.server/
    </VirtualHost>

    <VirtualHost *:80>
      ServerName       third.server
      DocumentRoot     /var/www
    </VirtualHost>
```
1. Add a php script to check the headers (/var/www/check.php):

``` php
<?php
if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
    $raw  = $_SERVER['HTTP_X_FORWARDED_HOST'];
    $host = strtok($_SERVER['HTTP_X_FORWARDED_HOST'], ',');
    die("Acccessed using '$host', taken from the X-Forwarded-Host header '$raw'\n");
}
$host = $_SERVER['HTTP_HOST'];
die("Acccessed using '$host', taken from the Host header (no forward proxy).\n");
```

Then you can use your browser or curl to test it:

<pre>
$> curl http://first.proxy/fwd.php
Acccessed using 'first.proxy', taken from the X-Forwarded-Host header 'first.proxy, second.proxy'
$> curl http://second.proxy/fwd.php
Acccessed using 'second.proxy', taken from the X-Forwarded-Host header 'second.proxy'
$> curl http://third.server/fwd.php
Acccessed using 'third.server', taken from the Host header (no forward proxy).
</pre>


As you can see, when accessing the script through at least two forward proxies, the X-Forwarded-Host header dows not contain a single URL, but multiple comma separated URLs.
