### PR TITLE
use the same signedRequest in the test

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -958,7 +958,7 @@ abstract class BaseFacebook
 
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);
-    
+
     $errno = curl_errno($ch);
     // CURLE_SSL_CACERT || CURLE_SSL_CACERT_BADFILE
     if ($errno == 60 || $errno == 77) {

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -829,10 +829,11 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
       'appId'  => self::APP_ID,
       'secret' => self::SECRET
     ));
-    $payload = $facebook->publicParseSignedRequest(self::kValidSignedRequest());
+    $sr = self::kValidSignedRequest();
+    $payload = $facebook->publicParseSignedRequest($sr);
     $this->assertNotNull($payload, 'Expected token to parse');
     $this->assertEquals($facebook->getSignedRequest(), null);
-    $_REQUEST['signed_request'] = self::kValidSignedRequest();
+    $_REQUEST['signed_request'] = $sr;
     $this->assertEquals($facebook->getSignedRequest(), $payload);
   }
 


### PR DESCRIPTION
`makeSignedRequest()` uses `time()` which might straddle a second boundary. Lets not call it twice.

Closes #117
