### PR TITLE
Don't check against CSRF if there was no state (code) generated.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -699,7 +699,7 @@ abstract class BaseFacebook
    *               code could not be determined.
    */
   protected function getCode() {
-    if (!isset($_REQUEST['code']) || !isset($_REQUEST['state']) || $this->state === null) {
+    if (!isset($_REQUEST['code']) || !isset($_REQUEST['state'])) {
       return false;
     }
     if ($this->state === $_REQUEST['state']) {


### PR DESCRIPTION
If in a signle handler you call the getCode twice, the function
logs that there was a Token mismatch at ERROR level. This is not
valid because the functions resets the state but forgets to check
against it. 
