### PR TITLE
If the state is null don't check for CSRF

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -721,7 +721,7 @@ abstract class BaseFacebook
    *               code could not be determined.
    */
   protected function getCode() {
-    if (!isset($_REQUEST['code']) || !isset($_REQUEST['state'])) {
+    if (!isset($_REQUEST['code']) || !isset($_REQUEST['state']) || !isset($this->state)) {
       return false;
     }
     if ($this->state === $_REQUEST['state']) {


### PR DESCRIPTION
When the state is not set or has done it's job  (nullified)  return false
