### PR TITLE
Removed deprecated getLoginStatusUrl

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -660,21 +660,6 @@ abstract class BaseFacebook
   }
 
   /**
-   * Get a login status URL to fetch the status from Facebook.
-   *
-   * @param array $params Provide custom parameters
-   * @return string The URL for the logout flow
-   */
-  public function getLoginStatusUrl($params=array()) {
-    return $this->getLoginUrl(
-      array_merge(array(
-        'response_type' => 'code',
-        'display' => 'none',
-      ), $params)
-    );
-  }
-
-  /**
    * Make an API call.
    *
    * @return mixed The decoded response


### PR DESCRIPTION
This method does not work, has been deprecated, and was removed from the docs some time ago.
