### PR TITLE
Don't close CURL handler when specified

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -906,13 +906,15 @@ abstract class BaseFacebook
    *
    * @param string $url The URL to make the request to
    * @param array $params The parameters to use for the POST body
-   * @param CurlHandler $ch Initialized curl handle
+   * @param CurlHandler $uch Initialized curl handle
    *
    * @return string The response text
    */
-  protected function makeRequest($url, $params, $ch=null) {
-    if (!$ch) {
+  protected function makeRequest($url, $params, $uch=null) {
+    if (!$uch) {
       $ch = curl_init();
+    } else {
+      $ch = & $uch;
     }
 
     $opts = self::$CURL_OPTS;
@@ -974,7 +976,11 @@ abstract class BaseFacebook
       curl_close($ch);
       throw $e;
     }
-    curl_close($ch);
+    
+    if ($uch === null) {
+      curl_close( $ch );
+	  }
+
     return $result;
   }
 


### PR DESCRIPTION
I think that if we pass a CURL handler to the makeRequest method, that method should not close the handler, instead it should relegate that process to the one that open it. This will allow us to reuse the same handler to make multiple calls to the API without keep opening and closing it.
