### PR TITLE
is_int that are used by FacebookException is too strict

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -45,8 +45,8 @@ class FacebookApiException extends Exception
     $this->result = $result;
 
     $code = 0;
-    if (isset($result['error_code']) && is_int($result['error_code'])) {
-      $code = $result['error_code'];
+    if (isset($result['error_code']) && preg_match('/^0$|^-?[1-9][0-9]*$/', $result['error_code'])) {
+      $code = (int) $result['error_code'];
     }
 
     if (isset($result['error_description'])) {


### PR DESCRIPTION
Even if $result ['error_code']  is natural number, it might be string.
is_int so return true if and only if the type of a variable is integer, the decision I think this is one of the too strict.
#### Now (is_int)

| value | return |
| --- | --- |
| 0 | true |
| '0' | false |
| 500 | true |
| '500' | false |
| '001' | false |
| 'not int' | false |
#### Fixed (my preg_match check)

| value | return |
| --- | --- |
| 0 | true |
| '0' | true |
| 500 | true |
| '500' | true |
| '001' | false |
| 'not int' | false |
