### PR TITLE
Moved persistent key validation to BaseFacebook

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -171,6 +171,14 @@ abstract class BaseFacebook
   );
 
   /**
+   * Supported keys for persistent data
+   *
+   * @var array
+   */
+  protected static $kSupportedKeys =
+    array('state', 'code', 'access_token', 'user_id');
+
+  /**
    * The Application ID.
    *
    * @var string
@@ -1479,6 +1487,16 @@ abstract class BaseFacebook
       return true;
     }
     return substr($big, -$len) === $small;
+  }
+
+  /**
+   * Validates a session key
+   *
+   * @param string
+   * @return boolean
+   */
+  public static function isValidSessionKey($key) {
+    return in_array($key, self::$kSupportedKeys);
   }
 
   /**

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -76,14 +76,6 @@ class Facebook extends BaseFacebook
   }
 
   /**
-   * Supported keys for persistent data
-   *
-   * @var array
-   */
-  protected static $kSupportedKeys =
-    array('state', 'code', 'access_token', 'user_id');
-
-  /**
    * Initiates Shared Session
    */
   protected function initSharedSession() {
@@ -135,7 +127,7 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::setPersistentData()
    */
   protected function setPersistentData($key, $value) {
-    if (!in_array($key, self::$kSupportedKeys)) {
+    if (!self::isValidSessionKey($key)) {
       self::errorLog('Unsupported key passed to setPersistentData.');
       return;
     }
@@ -150,7 +142,7 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::getPersistentData()
    */
   protected function getPersistentData($key, $default = false) {
-    if (!in_array($key, self::$kSupportedKeys)) {
+    if (!self::isValidSessionKey($key)) {
       self::errorLog('Unsupported key passed to getPersistentData.');
       return $default;
     }
@@ -166,7 +158,7 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::clearPersistentData()
    */
   protected function clearPersistentData($key) {
-    if (!in_array($key, self::$kSupportedKeys)) {
+    if (!self::isValidSessionKey($key)) {
       self::errorLog('Unsupported key passed to clearPersistentData.');
       return;
     }

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -1823,6 +1823,18 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
     $this->assertEquals('https', $fb->publicGetHttpProtocol());
   }
 
+  public function testValidatesSessionKeys() {
+    $fb = new FBValidation(array(
+      'appId'  => self::APP_ID,
+      'secret' => self::SECRET,
+    ));
+    $this->assertTrue($fb::publicIsValidSessionKey('state'), '"state" should be a valid session key');
+    $this->assertTrue($fb::publicIsValidSessionKey('code'), '"code" should be a valid session key');
+    $this->assertTrue($fb::publicIsValidSessionKey('access_token'), '"access_token" should be a valid session key');
+    $this->assertTrue($fb::publicIsValidSessionKey('user_id'), '"user_id" should be a valid session key');
+    $this->assertFalse($fb::publicIsValidSessionKey('foo'), '"foo" should not be a valid session key');
+  }
+
   /**
    * @dataProvider provideEndsWith
    */
@@ -2090,5 +2102,11 @@ class FBPublicState extends TransientFacebook {
 
   public function publicGetState() {
     return $this->state;
+  }
+}
+
+class FBValidation extends TransientFacebook {
+  public static function publicIsValidSessionKey($key) {
+    return self::isValidSessionKey($key);
   }
 }


### PR DESCRIPTION
When you extend the `BaseFacebook` class with your own persistent data handling methods, you're forced to handle session key validation on your own. And in order to write your own `clearAllPersistentData()` you have to have a full list of supported keys.

This functionality should be offered at the base class out-of-the-box so that the custom class can handle setting & unsetting persistent data without also having to worrying about session key validation.

This is also helpful for future cases when there might be another key needed by the SDK. Updates can be made to the base class and the validation will cascade.
