### PR TITLE
Moved the curl check to the Facebook.php file

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -15,9 +15,6 @@
  * under the License.
  */
 
-if (!function_exists('curl_init')) {
-  throw new Exception('Facebook needs the CURL PHP extension.');
-}
 if (!function_exists('json_decode')) {
   throw new Exception('Facebook needs the JSON PHP extension.');
 }

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -15,6 +15,10 @@
  * under the License.
  */
 
+if (!function_exists('curl_init')) {
+  throw new Exception('Facebook needs the CURL PHP extension.');
+}
+
 require_once "base_facebook.php";
 
 /**


### PR DESCRIPTION
If you have your own implementation of `makeRequest()` that doesn't use cURL and cURL is not installed on your sever, the SDK will not load since it does a check at the very top of "base_facebook.php". I moved this to "facebook.php" since it only applies to those using the default implementation.
