### PR TITLE
Added an interface when extending the BaseFacebook class

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -112,6 +112,49 @@ class FacebookApiException extends Exception
 }
 
 /**
+ * Required methods when extending from the abstract BaseFacebook class
+ *
+ * @see https://developers.facebook.com/docs/reference/php/
+ */
+interface BaseFacebookInterface
+{
+  /**
+   * Stores the given key-value pair, so that future calls to
+   * getPersistentData for a given key return the related value.
+   *
+   * @param string
+   * @param mixed
+   * @return void
+   */
+  public function setPersistentData($key, $value);
+
+  /**
+   * Get the stored value for a given key which was set with
+   * BaseFacebook::setPersistentData.
+   *
+   * @param string
+   * @param boolean
+   * @return mixed
+   */
+  public function getPersistentData($key, $default = null);
+
+  /**
+   * Clears the stored value for a given key.
+   *
+   * @param string
+   * @return void
+   */
+  public function clearPersistentData($key);
+
+  /**
+   * Clears all stored key-value pairs.
+   *
+   * @return void
+   */
+  public function clearAllPersistentData();
+}
+
+/**
  * Provides access to the Facebook Platform.  This class provides
  * a majority of the functionality needed, but the class is abstract
  * because it is designed to be sub-classed.  The subclass must

--- a/src/facebook.php
+++ b/src/facebook.php
@@ -21,7 +21,7 @@ require_once "base_facebook.php";
  * Extends the BaseFacebook class with the intent of using
  * PHP sessions to store user ids and access tokens.
  */
-class Facebook extends BaseFacebook
+class Facebook extends BaseFacebook implements BaseFacebookInterface
 {
   /**
    * Cookie prefix
@@ -134,7 +134,7 @@ class Facebook extends BaseFacebook
    *
    * @see BaseFacebook::setPersistentData()
    */
-  protected function setPersistentData($key, $value) {
+  public function setPersistentData($key, $value) {
     if (!in_array($key, self::$kSupportedKeys)) {
       self::errorLog('Unsupported key passed to setPersistentData.');
       return;
@@ -149,7 +149,7 @@ class Facebook extends BaseFacebook
    *
    * @see BaseFacebook::getPersistentData()
    */
-  protected function getPersistentData($key, $default = false) {
+  public function getPersistentData($key, $default = false) {
     if (!in_array($key, self::$kSupportedKeys)) {
       self::errorLog('Unsupported key passed to getPersistentData.');
       return $default;
@@ -165,7 +165,7 @@ class Facebook extends BaseFacebook
    *
    * @see BaseFacebook::clearPersistentData()
    */
-  protected function clearPersistentData($key) {
+  public function clearPersistentData($key) {
     if (!in_array($key, self::$kSupportedKeys)) {
       self::errorLog('Unsupported key passed to clearPersistentData.');
       return;
@@ -182,7 +182,7 @@ class Facebook extends BaseFacebook
    *
    * @see BaseFacebook::clearAllPersistentData()
    */
-  protected function clearAllPersistentData() {
+  public function clearAllPersistentData() {
     foreach (self::$kSupportedKeys as $key) {
       $this->clearPersistentData($key);
     }


### PR DESCRIPTION
An interface to be implemented when extending from the `BaseFacebook` class. This will allow for type hinting dependency injection to ensure we're getting the correct object. So we can do stuff like this:

``` php
public function __construct(\BaseFacebookInterface $sdk)
{
    $this->sdk = $sdk;
}
```

And for custom implementations, they would just do this:

``` php
class MyFacebook extends \BaseFacebook implements \BaseFacebookInterface {}
```

This would cross off one of the wishlist items from #177.
