### PR TITLE
Added hipster badges to readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,10 @@
 Facebook PHP SDK (v.3.2.3)
+==========================
+
+[![Build Status](http://img.shields.io/travis/facebook/facebook-php-sdk.svg)](https://travis-ci.org/facebook/facebook-php-sdk)
+[![Total Downloads](http://img.shields.io/packagist/dm/facebook/php-sdk.svg)](https://packagist.org/packages/facebook/php-sdk)
+[![Latest Stable Version](http://img.shields.io/packagist/v/facebook/php-sdk.svg)](https://packagist.org/packages/facebook/php-sdk)
+
 
 The [Facebook Platform](http://developers.facebook.com/) is
 a set of APIs that make your app more social.
@@ -42,7 +48,7 @@ if ($user) {
 You can make api calls by choosing the `HTTP method` and setting optional `parameters`:
 ```php
 $facebook->api('/me/feed/', 'post', array(
-	'message' => 'I want to display this message on my wall'
+  'message' => 'I want to display this message on my wall'
 ));
 ```
 


### PR DESCRIPTION
For solidarity with other hipster PHP packages, I added "Travis CI", "Packagist downloads" and "Packagist stable version" badges to the readme. I also made the title a proper header with markdown.

Oh - and converted a tab to spaces in the `$facebook->api()` example. :)
