### PR TITLE
Fix error message for testGraphAPIOAuthSpecError

### DIFF
--- a/tests/tests.php
+++ b/tests/tests.php
@@ -594,7 +594,7 @@ class PHPSDKTestCase extends PHPUnit_Framework_TestCase {
       $this->fail('Should not get here.');
     } catch(FacebookApiException $e) {
       // means the server got the access token
-      $msg = 'invalid_request: An active access token must be used '.
+      $msg = 'OAuthException: An active access token must be used '.
              'to query information about the current user.';
       $this->assertEquals($msg, (string) $e,
                           'Expect the invalid session message.');


### PR DESCRIPTION
Found in HHVM test runs: http://hhvm.com/frameworks - broke in push on Tuesday 2014-06-24.
