### PR TITLE
Add mbstring to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=5.2.0",
         "ext-curl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
It needs to be enabled for the SDK to work in Heroku. 
See: http://stackoverflow.com/questions/24140186/facebook-php-sdk-error-mb-substr
