### PR TITLE
Evaluate the env 'HTTPS' without a case.

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -1225,7 +1225,7 @@ abstract class BaseFacebook
     }
     /*apache + variants specific way of checking for https*/
     if (isset($_SERVER['HTTPS']) &&
-        ($_SERVER['HTTPS'] === 'on' || $_SERVER['HTTPS'] == 1)) {
+        (strcasecmp($_SERVER['HTTPS'], 'on') === 0 || $_SERVER['HTTPS'] == 1)) {
       return 'https';
     }
     /*nginx way of checking for https*/


### PR DESCRIPTION
Environment of My Service(Using HTTPS)
- ServerEnv HTTPS's value is 'ON' (not 'on').
- Port of https is not 443/tcp.

I expect to get 'https' from Facebook::getHttpProtocol() .
But in this case, Facebook::getHttpProtocol() returns 'http'.

So I changed the condition to evaluate $_SERVER['HTTPS'].
