### PR TITLE
Mistake in CSRF mismatch logging

### DIFF
--- a/src/base_facebook.php
+++ b/src/base_facebook.php
@@ -715,7 +715,9 @@ abstract class BaseFacebook
         $this->clearPersistentData('state');
         return $_REQUEST['code'];
     }
-    self::errorLog('CSRF state token does not match one provided.');
+    if ($this->state !== NULL) { // CSRF mismatch only if CSRF token already generated
+        self::errorLog('CSRF state token does not match one provided.');
+    }
 
     return false;
   }


### PR DESCRIPTION
If no state was set (csrf protection token), do not raise error when not identical to $_REQUEST['state'].
Refreshing url with old token cause this error unnecessary.
